### PR TITLE
Don't throw an error if a user enters a string as a token.

### DIFF
--- a/allauth_2fa/forms.py
+++ b/allauth_2fa/forms.py
@@ -39,7 +39,11 @@ class TOTPDeviceForm(forms.Form):
         self.metadata = metadata or {}
 
     def clean_token(self):
-        token = int(self.cleaned_data.get('token'))
+        try:
+            token = int(self.cleaned_data.get('token'))
+        except ValueError:
+            # valid will never equal true in this case.
+            token = None
         valid = False
         t0s = [self.t0]
         key = unhexlify(self.key.encode())


### PR DESCRIPTION
If the user enters a string as a token, currently Django throws a 500 error due to an integer conversion failing. This should just be recognized as an invalid token.